### PR TITLE
Max/main

### DIFF
--- a/shremote.py
+++ b/shremote.py
@@ -568,16 +568,19 @@ class Command:
         elif 'enforce_duration' in self.program.cfg:
             enforce_duration_loc = self.program.cfg
 
+        #If specificed, default to self.duration or can take a value
         if enforce_duration_loc is not None:
             enforce_duration = enforce_duration_loc.formatted('enforce_duration', **self.dict())
-            if not isinstance(enforce_duration, bool):
-                log_fatal("{}: enforce_duration must be a boolean".format(program_name))
             if enforce_duration == True:
                 if self.duration is None:
                     log_fatal(
-                        "{}: Specified enforce_duration with no duration specified".format(program_name)
+                        "{}: Specified enforce_duration=True with no duration specified".format(program_name)
                     )
                 self.enforced_duration = self.duration - 1
+            elif isinstance(enforce_duration, int) and enforce_duration > 0:
+                self.enforced_duration = enforce_duration
+        elif self.duration is not None:
+            self.enforced_duration = self.duration - 1
 
     def dict(self, **kwargs):
         d = {}

--- a/shremote.py
+++ b/shremote.py
@@ -256,6 +256,8 @@ class Config(object):
     def formatted(self, key, **kwargs):
         if isinstance(self.dict[key], Config):
             return self.dict[key]
+        if isinstance(self.dict[key], bool):
+            return self.dict[key]
         if isinstance(self.dict[key], str):
             st = self.dict[key]
             while '{' in st:

--- a/shremote.py
+++ b/shremote.py
@@ -825,6 +825,8 @@ class TestRunner:
         shutil.copytree(self.output_dir, self.export_dir)
 
     def verify_init_cmds(self):
+        if 'init_cmds' not in self.cfg:
+            return
         log_info("Verifying init cmds")
         for cmd, _ in self.cfg.init_cmds.items():
             cmd = self.cfg.init_cmds.formatted(cmd)
@@ -834,6 +836,8 @@ class TestRunner:
             log("Verified command {}".format(cmd))
 
     def run_init_cmds(self):
+        if 'init_cmds' not in self.cfg:
+            return
         for cmd, _ in self.cfg.init_cmds.items():
             cmd = self.cfg.init_cmds.formatted(cmd)
             check_rtn = 0
@@ -867,6 +871,8 @@ class TestRunner:
             call(cmd, raise_error=True, check_return=check_rtn)
 
     def verify_files(self):
+        if 'files' not in self.cfg:
+            return
         log_info("Verifying files")
         for name, file in self.cfg.files.dict.items():
             log("Verifying {}".format(name))
@@ -895,6 +901,8 @@ class TestRunner:
                     log('Verified scp: {}'.format(cmd))
 
     def copy_files(self):
+        if 'files' not in self.cfg:
+            return
         for name, file in self.cfg.files.dict.items():
             src = file.formatted('src')
             dst = file.formatted('dst')

--- a/shremote.py
+++ b/shremote.py
@@ -19,8 +19,6 @@ import signal
 import traceback
 from threading import Thread
 import threading
-from inspect import currentframe, getframeinfo
-from pathlib import Path
 
 COLORS = dict(
     END='\033[0m',
@@ -385,7 +383,8 @@ class Log:
         else:
             log_warn("Cannot locate logs in cfg.logs.dir, cfg.programs.log_dir or cfg.dirs.log_dir.\
                       Using user home directory.")
-            return str(Path.home())
+            Config.instance().set_permanent(log_dir = '~/')
+            return '~/'
 
     def __init__(self, log_name, log_cfg, label=None):
         log("Initializing log {}".format(log_name))

--- a/shremote.py
+++ b/shremote.py
@@ -159,14 +159,18 @@ class Config(object):
         if cls.instance_ is None:
             raise Exception("Config instance not instantiated")
 
-        # TODO: Regex match, in case string contains \{
-        while '{' in st:
+        # TODO: check if open bracket is matched
+        while len([m.start() for m in re.finditer('[^\\\\]\{', st)]) > 0:
+            st = st.replace('\{', '\{{')
+            st = st.replace('\}', '\}}')
             try:
                 st = st.format(cls.instance_, **kwargs)
             except Exception as e:
                 log_error("Error formatting:\n\t{}\nwith\n\t{}\nError: {}".format(st, kwargs, e))
                 raise
 
+        st = st.replace('\{', '{')
+        st = st.replace('\}', '}')
         return cls.eval(st)
 
     @staticmethod

--- a/shremote.py
+++ b/shremote.py
@@ -355,8 +355,12 @@ class Log:
             return Config.instance().logs.dir
         elif 'log_dir' in Config.instance().programs:
             return Config.instance().programs.log_dir
+        elif 'log_dir' in Config.instance().dirs:
+            return Config.instance().dirs.log_dir
         else:
-            raise Exception("Cannot locate logs in cfg.logs.dir or cfg.programs.log_dir")
+            raise Exception(
+                "Cannot locate logs in cfg.logs.dir, cfg.programs.log_dir or cfg.dirs.log_dir"
+            )
 
     def __init__(self, log_name, log_cfg):
         log("Initializing log {}".format(log_name))
@@ -769,7 +773,7 @@ class TestRunner:
             self.raw_cfg = yaml.load(f, Loader)
 
         call("mkdir -p %s" % self.output_dir, raise_error=True)
-        self.cfg = Config(self.raw_cfg, label=label, args=args_dict, out=self.output_dir, 
+        self.cfg = Config(self.raw_cfg, label=label, args=args_dict, out=self.output_dir,
                           local_out = self.output_dir)
         self.open_log()
         self.cfg.set_permanent(remote_out = Log.get_log_dir())
@@ -1136,7 +1140,6 @@ if __name__ == '__main__':
 
     tester = TestRunner(args.cfg_file, args.label, args.out, args.export, args.test, args_dict)
 
-
     if args.stop_only:
         tester.stop_all()
     elif args.get_only:
@@ -1150,4 +1153,3 @@ if __name__ == '__main__':
             tester.delete_dirs()
         tester.run()
         tester.close_log()
-

--- a/shremote.py
+++ b/shremote.py
@@ -362,7 +362,7 @@ class Log:
                 "Cannot locate logs in cfg.logs.dir, cfg.programs.log_dir or cfg.dirs.log_dir"
             )
 
-    def __init__(self, log_name, log_cfg):
+    def __init__(self, log_name, log_cfg, label=None):
         log("Initializing log {}".format(log_name))
         self.copied = defaultdict(lambda: False)
         self.cfg = log_cfg
@@ -370,6 +370,8 @@ class Log:
         self.has_dir = 'dir' in log_cfg
 
         self.log_dir = Log.get_log_dir()
+        if label:
+            self.log_dir = self.log_dir + '/' + label + '/'
 
         self.dir = log_cfg.get('dir', '')
         self.full_dir = Config.format(os.path.join(self.log_dir, self.dir, ''))
@@ -794,7 +796,7 @@ class TestRunner:
             for name, prog in self.cfg.programs.items():
                 if name != 'log_dir':
                     if 'log' in prog:
-                        Log(name, prog.log)
+                        Log(name, prog.log, label)
 
         self.programs = {}
         for name, prog in self.cfg.programs.items():

--- a/shremote.py
+++ b/shremote.py
@@ -102,10 +102,11 @@ def call(cmd, enforce_duration=None, check_return=False, raise_error=False):
     except CalledProcessError as err:
         if len(err.output) > 0:
             log("Command ", cmd, "output: ", err.output)
-        if check_return is not  False:
+        if check_return is not False:
+            #FIXME: this should look for 0, 137 (SIGINT) or 143 (SIGTERM)
             if err.returncode != check_return:
-                log_error("Command ", cmd, "\n\treturned: ", err.returncode,
-                          ". Expected: ", check_return,
+                log_error("Command ", cmd, "\n\treturned:", err.returncode,
+                          ". Expected:", check_return,
                           "\n\tIf this command should have executed anyway, add `check_rtn: False` to command")
                 log_error(traceback.format_exc())
                 error_event.set()

--- a/shremote.py
+++ b/shremote.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from collections import defaultdict
@@ -380,9 +380,8 @@ class Log:
             return Config.instance().dirs.log_dir
         else:
             log_warn("Cannot locate logs in cfg.logs.dir, cfg.programs.log_dir or cfg.dirs.log_dir.\
-                      Using Shremote directory.")
-            filename = getframeinfo(currentframe()).filename
-            return Path(filename).resolve().parent
+                      Using user home directory.")
+            return str(Path.home())
 
     def __init__(self, log_name, log_cfg, label=None):
         log("Initializing log {}".format(log_name))
@@ -534,7 +533,6 @@ class Program:
                 log_error("Error initializing program ", name)
                 raise
 
-# what happens if no begin is given?
 class Command:
 
     def __init__(self, program_name, cmd_cfg, index = None):
@@ -545,7 +543,7 @@ class Command:
 
         if 'begin' in cmd_cfg:
             begin_raw = cmd_cfg.formatted('begin')
-            self.begin = try_eval(begin_raw, 'begin')
+            self.begin = int(try_eval(begin_raw, 'begin'))
 
         self.index = index if index is not None else 0
         self.program = Program.get(program_name)

--- a/shremote.py
+++ b/shremote.py
@@ -527,10 +527,9 @@ def try_eval(raw, label):
         evaled = safe_eval(raw, label)
         if str(evaled) != str(raw): # Means that 'eval' did something
             log_warn("Specifying evaluatable begin without $(...) is deprecated: {}".format(raw))
-        return float(evaled)
+            return evaled
     except TypeError: # raw shouldn't have to be eval'd again
-        return float(raw)
-
+            return raw
 
 # what happens if no begin is given?
 class Command:
@@ -1037,7 +1036,6 @@ class TestRunner:
         for command in self.sorted_commands:
             self.event_log.append(command.stop())
 
-
     def get_logs(self):
         call("mkdir -p %s" % self.output_dir, raise_error=True)
 
@@ -1053,7 +1051,6 @@ class TestRunner:
 
         for filename in self.included_files:
             call('cp {} {}/'.format(filename, self.output_dir), raise_error=True)
-
 
     def write_log(self):
         output = open(os.path.join(self.output_dir, 'event_log.json'), 'w')

--- a/shremote.py
+++ b/shremote.py
@@ -558,7 +558,7 @@ class Command:
                 log_fatal("{}: Must specify a 'stop' command if duration is specified".format(
                           program_name))
             duration_raw = cmd_cfg.formatted('duration', **self.dict())
-            self.duration = float(try_eval(duration_raw, 'duration'))
+            self.duration = int(try_eval(duration_raw, 'duration'))
 
         #Enforce duration can be specified in the program or in the command
         self.enforced_duration = None

--- a/shremote.py
+++ b/shremote.py
@@ -532,7 +532,6 @@ def try_eval(raw, label):
 
 
 # what happens if no begin is given?
-# Is duration checked to be a number?
 class Command:
 
     def __init__(self, program_name, cmd_cfg, index = None):
@@ -618,7 +617,7 @@ class Command:
             starts.append(cmd)
             host.execute(cmd, self.program.fg, self.enforced_duration, self.program.check_rtn)
 
-            if self.program.stop is not None:
+            if self.program.stop is not None and self.duration is not None:
                 stop_cmd = self.program.stop_cmd(self.duration, **cmd_kwargs)
                 stops.append(stop_cmd)
                 host.execute(stop_cmd, False, None, False)
@@ -893,7 +892,7 @@ class TestRunner:
                                              addr=addr, **ssh.dict)
                     cmd = SCP_OUT_CMD.format(src=src, dst=dst, addr=addr, **ssh.dict)
 
-                    log('Verfied mkdir: {}'.format(ssh_cmd))
+                    log('Verified mkdir: {}'.format(ssh_cmd))
                     log('Verified scp: {}'.format(cmd))
 
     def copy_files(self):

--- a/shremote.py
+++ b/shremote.py
@@ -558,9 +558,6 @@ class Command:
             log_fatal("{}: Program requires a 'start' command".format(program_name))
 
         if 'duration' in cmd_cfg:
-            if self.program.stop is None:
-                log_fatal("{}: Must specify a 'stop' command if duration is specified".format(
-                          program_name))
             duration_raw = cmd_cfg.formatted('duration', **self.dict())
             self.duration = int(try_eval(duration_raw, 'duration'))
 
@@ -581,8 +578,12 @@ class Command:
                         "{}: Specified enforce_duration=True with no duration specified".format(program_name)
                     )
                 self.enforced_duration = self.duration - 1
-            elif isinstance(enforce_duration, int) and enforce_duration > 0:
+            elif isinstance(enforce_duration, (int, float)) and enforce_duration > 0:
                 self.enforced_duration = enforce_duration
+            else:
+                log_fatal(
+                    "{}: Unknown type for enforce_duration (should be boolean, int or float)".format(program_name)
+                )
         elif self.duration is not None:
             self.enforced_duration = self.duration - 1
 

--- a/shremote.py
+++ b/shremote.py
@@ -160,7 +160,7 @@ class Config(object):
             raise Exception("Config instance not instantiated")
 
         # TODO: check if open bracket is matched
-        while len([m.start() for m in re.finditer('[^\\\\]\{', st)]) > 0:
+        while len([m.start() for m in re.finditer(r'[^\\]\{', st)]) > 0:
             st = st.replace('\{', '\{{')
             st = st.replace('\}', '\}}')
             try:


### PR DESCRIPTION
This PR brings a couple of comfort changes:
- Allow config files without init_cmds or files configuration objects
- Use the experiment label to store programs' log files
- Allow log_dir to be specified in the dirs configuration object

And also:
- Booleans are now properly returned as such by the formatter
- A start command is always required for a program
- If enforce_duration is specified, a duration is required
- If a duration is specified, a stop command is required
- The stop command of a program is scheduled only if the command has been provided *and* a duration has been specified